### PR TITLE
Add tag with ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,5 @@ jobs:
           repository: wantedly/deployment-duplicator
           registry: quay.io
           tags: ${{ github.sha }}
+          tag_with_ref: true
           tag_with_sha: true


### PR DESCRIPTION
## Why

Latest image is not built at this time.
according to https://github.com/docker/build-push-action, it looks like we can use both `tag_with_ref` and `tag_with_sha`.

## What

Added `tag_with_sha`