### PR TITLE
Allow deployment-duplicator to edit deployments

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,26 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - duplication.k8s.wantedly.com
   resources:
   - deploymentcopies

--- a/controllers/deploymentcopy_controller.go
+++ b/controllers/deploymentcopy_controller.go
@@ -46,6 +46,8 @@ type DeploymentCopyReconciler struct {
 
 // +kubebuilder:rbac:groups=duplication.k8s.wantedly.com,resources=deploymentcopies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=duplication.k8s.wantedly.com,resources=deploymentcopies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 
 func (r *DeploymentCopyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Fetch the DeploymentCopy instance


### PR DESCRIPTION
## Why

deployment-duplicator lacks permissions to edit deployments

## What

Add same permissions as canary-controller
https://github.com/wantedly/canary-controller/blob/3087e403f109c7730390da2bb388a9cc1e5c43e1/pkg/controller/canary/canary_controller.go#L97-L98