### PR TITLE
Introduce NameSufiix 

### DIFF
--- a/api/v1beta1/deploymentcopy_types.go
+++ b/api/v1beta1/deploymentcopy_types.go
@@ -41,6 +41,10 @@ type DeploymentCopySpec struct {
 	// (optional) if defined, the copied deployment will have the specified Hostname
 	Hostname string `json:"hostname"`
 
+	// (optional) if defined, the copied deployment will have suffix with this value.
+	// When not defined, `.Matadata.Name` will be used
+	NameSuffix string `json:"nameSuffix"`
+
 	// name defined in `TargetDeploymentName` will be copied
 	TargetContainers []Container `json:"targetContainers"`
 }

--- a/config/samples/duplication_v1beta1_deploymentcopy.yaml
+++ b/config/samples/duplication_v1beta1_deploymentcopy.yaml
@@ -7,6 +7,7 @@ spec:
   customLabels:
     canary: "true"
   hostname: "hostname"
+  nameSuffix: "bar"
   targetContainers:
     - name: nginx
       image: nginx:latest

--- a/controllers/deploymentcopy_controller.go
+++ b/controllers/deploymentcopy_controller.go
@@ -60,6 +60,10 @@ func (r *DeploymentCopyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		return reconcile.Result{}, err
 	}
 
+	if instance.Spec.NameSuffix == "" {
+		instance.Spec.NameSuffix = instance.Name
+	}
+
 	// TODO(munisystem): Set a status into the DeploymentCopy resource if the target deployment doesn't exist
 	target, err := r.getDeployment(instance.Spec.TargetDeploymentName, instance.Namespace)
 	if err != nil {
@@ -114,7 +118,7 @@ func (r *DeploymentCopyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 	copiedDeploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-%s", copied.ObjectMeta.Name, instance.Name),
+			Name:        fmt.Sprintf("%s-%s", copied.ObjectMeta.Name, instance.Spec.NameSuffix),
 			Namespace:   instance.Namespace,
 			Labels:      labels,
 			Annotations: annotations,


### PR DESCRIPTION
## Why

In the discussion https://github.com/wantedly/deployment-duplicator/pull/1/files/a03aac79fe950e3bfe3af9efad470e407ab46272#r430971153, we decided not to have `NameSuffix`, instead we use `.metadata.name` for the purpose.
But after trying this controller in my environment I faced a minor problem.

When trying to copy deployment `some-very-long-deployment-name`, it's kind of reasonable to name `DeploymentCopy` `some-very-long-deployment-name` to avoid conflict in a namespace, which results in creating a deployment named `some-very-long-deployment-name-some-very-long-deployment-name`.
This is troublesome.

## What

Added an option to set suffix.
As @munisystem mentioned, k8s controllers usually don't ask suffix to set, but since `deployment` is an important resource and people expect they have meaningful names on it.
I think the option is useful.