### PR TITLE
[WIP]Follow original deployment update

### DIFF
--- a/controllers/deploymentcopy_controller.go
+++ b/controllers/deploymentcopy_controller.go
@@ -155,5 +155,6 @@ func (r *DeploymentCopyReconciler) getDeployment(name, namespace string) (*appsv
 func (r *DeploymentCopyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&duplicationv1beta1.DeploymentCopy{}).
+		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Why
Current controller implementation doesn't follow the source deployment update

## What
Make `deployment-duplicator` follow source deployment update

## Note
I (onsd) don't have permissions to change `deployment-duplicator` resources, so I haven't test it yet