### PR TITLE
use the context given by argument

### DIFF
--- a/controllers/deploymentcopy_controller.go
+++ b/controllers/deploymentcopy_controller.go
@@ -63,7 +63,7 @@ type DeploymentCopyReconciler struct {
 func (r *DeploymentCopyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Fetch the DeploymentCopy instance
 	instance := &duplicationv1beta1.DeploymentCopy{}
-	err := r.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
@@ -76,7 +76,7 @@ func (r *DeploymentCopyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// TODO(munisystem): Set a status into the DeploymentCopy resource if the target deployment doesn't exist
-	target, err := r.getDeployment(instance.Spec.TargetDeploymentName, instance.Namespace)
+	target, err := r.getDeployment(ctx, instance.Spec.TargetDeploymentName, instance.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
@@ -138,7 +138,7 @@ func (r *DeploymentCopyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	log.Info("try to create or update copied Deployment", "namespace", copiedDeploy.Namespace, "name", copiedDeploy.Name)
-	if _, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, copiedDeploy, func() error {
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, copiedDeploy, func() error {
 		copiedDeploy.Labels = labels
 		copiedDeploy.Annotations = annotations
 		copiedDeploy.Spec = spec
@@ -152,9 +152,9 @@ func (r *DeploymentCopyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return reconcile.Result{}, nil
 }
 
-func (r *DeploymentCopyReconciler) getDeployment(name, namespace string) (*appsv1.Deployment, error) {
+func (r *DeploymentCopyReconciler) getDeployment(ctx context.Context, name, namespace string) (*appsv1.Deployment, error) {
 	found := &appsv1.Deployment{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, found)
+	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, found)
 	return found, err
 }
 


### PR DESCRIPTION
## Why
By #26, Reconcile function has context by the argument


## What
replace context.TODO() by context given by arguments

```console
$ make test

/Users/taka/Workspace/github.com/wantedly/deployment-duplicator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/taka/Workspace/github.com/wantedly/deployment-duplicator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
KUBEBUILDER_ASSETS="/Users/taka/Library/Application Support/io.kubebuilder.envtest/k8s/1.23.3-darwin-amd64" go test ./... -coverprofile cover.out
?       github.com/wantedly/deployment-duplicator       [no test files]
?       github.com/wantedly/deployment-duplicator/api/v1beta1   [no test files]
gs
ok      github.com/wantedly/deployment-duplicator/controllers   5.785s  coverage: 88.7% of statements
?       github.com/wantedly/deployment-duplicator/controllers/testing   [no test files]
```