### PR TITLE
Configure appropriate affinity

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,22 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    # - arm64
+                    # - ppc64le
+                    # - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
## Why

Kubebuilder recommends adding an appropriate affinity https://github.com/kubernetes-sigs/kubebuilder/blob/v4.0.0/testdata/project-v4/config/manager/manager.yaml#L31-L50

For context within Wantedly: see https://github.com/wantedly/infrastructure/issues/12890

## What

Added affinity.

Note to the reviewer: this is a public repo.