### PR TITLE
kube-rbac-proxyをgcr.ioからquay.ioへ変更

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Why
- [GCR廃止に伴う影響範囲を特定し対策する · Issue #13917 · wantedly/infrastructure](https://github.com/wantedly/infrastructure/issues/13917#issuecomment-2846676903)

## What
- gcr.io から quay.io へ変更
- ref: https://quay.io/repository/brancz/kube-rbac-proxy?tab=tags&tag=latest